### PR TITLE
Fix MoviesAPI TV query URL

### DIFF
--- a/src/lib/MoviesAPI.ts
+++ b/src/lib/MoviesAPI.ts
@@ -10,7 +10,7 @@ export default class MoviesAPI {
     const url =
       type === "movie"
         ? `https://moviesapi.to/api/discover/movie?query=${query}&year=${year}`
-        : `https://moviesapi.to/api/discover/tv?query=${query}}`;
+        : `https://moviesapi.to/api/discover/tv?query=${query}`;
     try {
       const respose = await fetch(url, {
         method: "GET",


### PR DESCRIPTION
## Summary
- fix MoviesAPI TV endpoint string

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68735f5ac9f483338676152a9e0c01e3