### PR TITLE
Fix admin dashboard link typo

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -82,7 +82,7 @@ const Nav: FC = () => {
             <DropdownMenuSeparator className="bg-[#10141E]" />
             {customClaims?.admin ? (
               <DropdownMenuItem className="text-white text-xl">
-                <Link href="/admin-dashbaord">Admin Dashboard</Link>
+                <Link href="/admin-dashboard">Admin Dashboard</Link>
               </DropdownMenuItem>
             ) : null}
             <DropdownMenuItem className="text-white text-xl">


### PR DESCRIPTION
## Summary
- fix admin dashboard typo in nav menu

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735f66ec288333aaacc2fa1570b7b8