### PR TITLE
Add validation test for registerSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Running Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+
+This uses [Vitest](https://vitest.dev) for the test runner.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -44,6 +45,7 @@
     "eslint-config-next": "15.3.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/validation/__tests__/authSchema.test.ts
+++ b/src/validation/__tests__/authSchema.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { registerSchema } from '../authSchema'
+
+const baseData = {
+  email: 'user@example.com',
+  password: 'StrongP@ss1',
+}
+
+describe('registerSchema', () => {
+  it('rejects when passwords do not match', () => {
+    const result = registerSchema.safeParse({
+      ...baseData,
+      confirmPassword: 'WrongP@ss1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts matching passwords', () => {
+    const result = registerSchema.safeParse({
+      ...baseData,
+      confirmPassword: baseData.password,
+    })
+    expect(result.success).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add `vitest` test script and dev dependency
- document running tests
- add unit tests for `registerSchema`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735f6ebc608333b0585694b40fb496